### PR TITLE
BUG?: Ignore undefined values when generating attributes

### DIFF
--- a/src/element.ts
+++ b/src/element.ts
@@ -24,11 +24,14 @@ export const applyElementAttributes = (
 ) => {
   if (attributes) {
     return Object.keys(attributes)
+      .filter(
+        (key) => attributes[key] !== undefined && attributes[key] !== null
+      )
       .map(
         (key) =>
-          attributes[key] !== undefined ? ` ${key.replace(/([A-Z])/g, (g) => `-${g[0].toLowerCase()}`)}="${
+          ` ${key.replace(/([A-Z])/g, (g) => `-${g[0].toLowerCase()}`)}="${
             attributes[key]
-          }"` : ''
+          }"`
       )
       .join("");
   }

--- a/src/element.ts
+++ b/src/element.ts
@@ -26,9 +26,9 @@ export const applyElementAttributes = (
     return Object.keys(attributes)
       .map(
         (key) =>
-          ` ${key.replace(/([A-Z])/g, (g) => `-${g[0].toLowerCase()}`)}="${
+          attributes[key] !== undefined ? ` ${key.replace(/([A-Z])/g, (g) => `-${g[0].toLowerCase()}`)}="${
             attributes[key]
-          }"`
+          }"` : ''
       )
       .join("");
   }

--- a/src/test/element.spec.ts
+++ b/src/test/element.spec.ts
@@ -34,5 +34,13 @@ describe("Element", () => {
       });
       expect(attributeString).toEqual(' class="new" data-test="test"');
     });
+
+    it("should not include keys when their value is undefined in attributes", () => {
+      const attributeString = Element.applyElementAttributes({
+        class: "new",
+        dataTest: undefined,
+      });
+      expect(attributeString).toEqual(' class="new"');
+    });
   });
 });

--- a/src/test/element.spec.ts
+++ b/src/test/element.spec.ts
@@ -42,5 +42,13 @@ describe("Element", () => {
       });
       expect(attributeString).toEqual(' class="new"');
     });
+
+    it("should not include keys when their value is null in attributes", () => {
+       const attributeString = Element.applyElementAttributes({
+          class: "new",
+          dataTest: null,
+       });
+       expect(attributeString).toEqual(' class="new"');
+    });
   });
 });


### PR DESCRIPTION
Ran into this and thought it felt unexpected. If I'm building up an object for attributes in some process like

```
function makeThing({url, defaultThing = 100, defaultThing2 = undefined}) {
   const attr =  { blablabla, url, defaultThing, defaultThing2 };
   return [{ type: 'div', attributes: attr, content: [...]}]; 
}
```

Then it throws me off if I pass in something that's undefined because it shouldn't have a value and the resulting HTML generated is like:

```
<div defaultThing2="undefined" ...>
```

Does this seem like it would be a good addition to the library as you envisioned it? I know it would handy for me where I have a set of default properties for some elements but in some cases they get additional attributes but otherwise I want to leave them unset and not see them included.